### PR TITLE
Use the LOCALHOST_IPV4 instead of LOCAL_HOST.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-0.3.4:
+
+-------------
+0.3.4
+-------------
+
+* Adapt the **ts_tcpip** v1.0.0 to use the **LOCALHOST_IPV4** instead of **LOCAL_HOST**.
+
 .. _lsst.ts.m2gui-0.3.3:
 
 -------------

--- a/python/lsst/ts/m2gui/main_window.py
+++ b/python/lsst/ts/m2gui/main_window.py
@@ -27,7 +27,7 @@ import sys
 from datetime import datetime
 
 from lsst.ts.m2com import read_yaml_file
-from lsst.ts.tcpip import LOCAL_HOST
+from lsst.ts.tcpip import LOCALHOST_IPV4
 from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QMainWindow, QToolBar, QVBoxLayout, QWidget
 from qasync import QApplication, asyncSlot
@@ -219,7 +219,7 @@ class MainWindow(QMainWindow):
         default_settings = read_yaml_file(filepath)
 
         if is_simulation_mode:
-            default_settings["host"] = LOCAL_HOST
+            default_settings["host"] = LOCALHOST_IPV4
 
         model = Model(
             self.log,


### PR DESCRIPTION
Adapt the **ts_tcpip** v1.0.0 to use the **LOCALHOST_IPV4** instead of **LOCAL_HOST**.