### PR TITLE
Tickets/dm 38837

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ See [Building single-package documentation locally](https://developer.lsst.io/st
 
 ## Run GUI in Docker Container
 
+You need to set the QT environment variables:
+
+```bash
+export QT_API="PySide2"
+export PYTEST_QT_API="PySide2"
+```
+
 ### CentOS 7
 
 Forward GUI by:
@@ -83,7 +90,6 @@ The environment variable **TS_CONFIG_MTTCS_DIR** specifies [ts_config_mttcs](htt
 You can run the unit tests by:
 
 ```bash
-export PYTEST_QT_API="PySide2"
 pytest tests/
 ```
 

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,18 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-0.4.2:
+
+-------------
+0.4.2
+-------------
+
+* Support the bit status in ``Model.set_bit_digital_status()``.
+* Set the bit status and control parameters in ``Model.enter_diagnostic()``.
+* Do not report the control status under the state transitoin related commands (except the ``fault()``) in ``Model``.
+* Update the ``TabDiagnostics._callback_control_digital_status()`` to check the correct local mode to switch the buttons of digital outputs.
+* Update the ``LayoutLocalMode._callback_signal_control()`` that do not show the buttons when the system is doing the mode transition.
+
 .. _lsst.ts.m2gui-0.4.1:
 
 -------------

--- a/tests/layout/test_layout_control_mode.py
+++ b/tests/layout/test_layout_control_mode.py
@@ -102,6 +102,10 @@ async def test_switch_force_balance_system(
     # Sleep so the event loop can access CPU to handle the signal
     await asyncio.sleep(15)
 
+    # Trigger the control signal to let the buttons change the status
+    widget_async.model.report_control_status()
+    await asyncio.sleep(1)
+
     assert widget_async.model.local_mode == LocalMode.Enable
 
     assert widget_async.model.is_closed_loop is False

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -199,12 +199,6 @@ async def test_reboot_controller_exception(model: Model) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_bit_digital_status_exception(model: Model) -> None:
-    with pytest.raises(RuntimeError):
-        await model.set_bit_digital_status(0)
-
-
-@pytest.mark.asyncio
 async def test_command_script_exception(model: Model) -> None:
     with pytest.raises(RuntimeError):
         await model.command_script(CommandScript.LoadScript)


### PR DESCRIPTION
* Support the bit status in ``Model.set_bit_digital_status()``.
* Set the bit status and control parameters in ``Model.enter_diagnostic()``.
* Do not report the control status under the state transitoin related commands (except the ``fault()``) in ``Model``.
* Update the ``TabDiagnostics._callback_control_digital_status()`` to check the correct local mode to switch the buttons of digital outputs.
* Update the ``LayoutLocalMode._callback_signal_control()`` that do not show the buttons when the system is doing the mode transition.