### PR TITLE
Tickets/dm 38791

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,22 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-0.4.3:
+
+-------------
+0.4.3
+-------------
+
+* Rename the "isInterlockOn" with "isInterlockEnabled" to be consistent with the controller.
+The indicator's color should be green instead of red when the status is on.
+* Simplify the ``UtilityMonitor.update_forces()`` to remove the check of force change.
+* Update the ``Model.connect()`` to actively clear the error if any when the connection is constructed.
+* Update the ``UtilityMonitor.update_position()`` to publish the position by IMS.
+* Add the ``TabRigidBodyPos._create_group_ims_position()`` to show the position by IMS.
+* Change the digit in detailed force widget.
+* Update the condition to trigger the ``Model.fault()``.
+* Update the ``Model._process_telemetry()`` to deal with the condition that the hardpoint correction of tangent link might be empty.
+
 .. _lsst.ts.m2gui-0.4.2:
 
 -------------

--- a/python/lsst/ts/m2gui/controltab/tab_detailed_force.py
+++ b/python/lsst/ts/m2gui/controltab/tab_detailed_force.py
@@ -212,11 +212,11 @@ class TabDetailedForce(TabDefault):
         for key in vars(self._forces_latest).keys():
             field = getattr(self._forces_latest, key)
 
-            is_interger = key in ("encoder_count", "step")
-
             for idx in range(NUM_ACTUATOR):
-                if is_interger:
+                if key in ("encoder_count", "step"):
                     self._forces[key][idx].setText(str(field[idx]))
+                elif key == "position_in_mm":
+                    self._forces[key][idx].setText("%.4f" % field[idx])
                 else:
                     self._forces[key][idx].setText("%.2f" % field[idx])
 

--- a/python/lsst/ts/m2gui/controltab/tab_overview.py
+++ b/python/lsst/ts/m2gui/controltab/tab_overview.py
@@ -145,7 +145,6 @@ class TabOverview(TabDefault):
 
         if indicator.text() in (
             "isAlarmOn",
-            "isInterlockOn",
             "isCellTemperatureHigh",
         ):
             return Qt.red

--- a/python/lsst/ts/m2gui/signals.py
+++ b/python/lsst/ts/m2gui/signals.py
@@ -163,9 +163,15 @@ class SignalDetailedForce(QtCore.QObject):
 class SignalPosition(QtCore.QObject):
     """Position signal to send the rigid body position."""
 
-    # Rigid body position as a list: [x, y, z, rx, ry, rz]. The unit of x, y,
-    # and z is um. The unit of rx, ry, and ry is arcsec.
+    # Rigid body position as a list: [x, y, z, rx, ry, rz] based on the
+    # hardpoint displacement. The unit of x, y, and z is um. The unit of rx,
+    # ry, and ry is arcsec.
     position = QtCore.Signal(object)
+
+    # Rigid body position as a list: [x, y, z, rx, ry, rz] based on the
+    # independent measurement system (IMS). The unit of x, y, and z is um. The
+    # unit of rx, ry, and ry is arcsec.
+    position_ims = QtCore.Signal(object)
 
 
 class SignalScript(QtCore.QObject):

--- a/tests/controltab/test_tab_detailed_force.py
+++ b/tests/controltab/test_tab_detailed_force.py
@@ -48,7 +48,7 @@ async def test_callback_time_out(widget: TabDetailedForce) -> None:
     assert widget._forces["f_hc"][3].text() == "1.23"
     assert widget._forces["f_cur"][5].text() == "0.20"
     assert widget._forces["f_error"][7].text() == "0.25"
-    assert widget._forces["position_in_mm"][10].text() == "123.00"
+    assert widget._forces["position_in_mm"][10].text() == "123.0000"
     assert widget._forces["step"][13].text() == "34"
 
 

--- a/tests/controltab/test_tab_rigid_body_pos.py
+++ b/tests/controltab/test_tab_rigid_body_pos.py
@@ -92,10 +92,21 @@ async def test_callback_clear_values_absolute(
 
 @pytest.mark.asyncio
 async def test_callback_position(widget: TabRigidBodyPos) -> None:
-    widget.model.utility_monitor.update_position(1, 2, 3, 4, 5, 6)
+    widget.model.utility_monitor.update_position(1, 2, 3, 4, 5, 6, is_ims=False)
 
     # Sleep so the event loop can access CPU to handle the signal
     await asyncio.sleep(1)
 
     for idx, axis in enumerate(widget.AXES):
         assert widget._position[axis].text() == str(idx + 1)
+
+
+@pytest.mark.asyncio
+async def test_callback_position_ims(widget: TabRigidBodyPos) -> None:
+    widget.model.utility_monitor.update_position(1, 2, 3, 4, 5, 6, is_ims=True)
+
+    # Sleep so the event loop can access CPU to handle the signal
+    await asyncio.sleep(1)
+
+    for idx, axis in enumerate(widget.AXES):
+        assert widget._position_ims[axis].text() == str(idx + 1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -55,6 +55,9 @@ def model() -> Model:
 async def model_async() -> Model:
     async with Model(logging.getLogger(), is_simulation_mode=True) as model_sim:
         await model_sim.connect()
+
+        assert model_sim.fault_manager.has_error() is False
+
         yield model_sim
 
 
@@ -389,6 +392,21 @@ def test_process_telemetry(qtbot: QtBot, model: Model) -> None:
         model._process_telemetry(
             message={
                 "id": "position",
+                "x": 1,
+                "y": 1,
+                "z": 1,
+                "xRot": 1,
+                "yRot": 1,
+                "zRot": 1,
+            }
+        )
+
+    with qtbot.waitSignal(
+        model.utility_monitor.signal_position.position_ims, timeout=TIMEOUT
+    ):
+        model._process_telemetry(
+            message={
+                "id": "positionIMS",
                 "x": 1,
                 "y": 1,
                 "z": 1,

--- a/tests/test_utility_monitor.py
+++ b/tests/test_utility_monitor.py
@@ -60,6 +60,7 @@ def test_report_utility_status(qtbot: QtBot, utility_monitor: UtilityMonitor) ->
         utility_monitor.signal_detailed_force.forces,
         utility_monitor.signal_detailed_force.force_error_tangent,
         utility_monitor.signal_position.position,
+        utility_monitor.signal_position.position_ims,
     ]
     with qtbot.waitSignals(signals, timeout=TIMEOUT):
         utility_monitor.report_utility_status()
@@ -368,12 +369,6 @@ def test_update_forces(qtbot: QtBot, utility_monitor: UtilityMonitor) -> None:
     assert id(utility_monitor.forces) == id(actuator_force)
     assert utility_monitor.forces.f_cur == actuator_force.f_cur
 
-    # There should be no change
-    actuator_force = utility_monitor.get_forces()
-    actuator_force.f_cur[1] = 100.001
-    with qtbot.assertNotEmitted(signal, wait=TIMEOUT):
-        utility_monitor.update_forces(actuator_force)
-
     # Current position is changed
     actuator_force = utility_monitor.get_forces()
     actuator_force.position_in_mm[1] = 100
@@ -423,11 +418,24 @@ def test_update_force_error_tangent(
 def test_update_position(qtbot: QtBot, utility_monitor: UtilityMonitor) -> None:
     signal = utility_monitor.signal_position.position
     with qtbot.waitSignal(signal, timeout=TIMEOUT):
-        utility_monitor.update_position(0.1, 0.23, 0.62, 3, 1.03, 1.06)
+        utility_monitor.update_position(0.1, 0.23, 0.62, 3, 1.03, 1.06, is_ims=False)
 
     assert utility_monitor.position == [0.1, 0.2, 0.6, 3, 1, 1.1]
 
     with qtbot.assertNotEmitted(signal, wait=TIMEOUT):
-        utility_monitor.update_position(0.11, 0.23, 0.62, 3, 1.03, 1.06)
+        utility_monitor.update_position(0.11, 0.23, 0.62, 3, 1.03, 1.06, is_ims=False)
 
     assert utility_monitor.position[0] == 0.1
+
+
+def test_update_position_ims(qtbot: QtBot, utility_monitor: UtilityMonitor) -> None:
+    signal = utility_monitor.signal_position.position_ims
+    with qtbot.waitSignal(signal, timeout=TIMEOUT):
+        utility_monitor.update_position(0.1, 0.23, 0.62, 3, 1.03, 1.06, is_ims=True)
+
+    assert utility_monitor.position_ims == [0.1, 0.2, 0.6, 3, 1, 1.1]
+
+    with qtbot.assertNotEmitted(signal, wait=TIMEOUT):
+        utility_monitor.update_position(0.11, 0.23, 0.62, 3, 1.03, 1.06, is_ims=True)
+
+    assert utility_monitor.position_ims[0] == 0.1


### PR DESCRIPTION
* Rename the "isInterlockOn" with "isInterlockEnabled" to be consistent with the controller.
The indicator's color should be green instead of red when the status is on.
* Simplify the ``UtilityMonitor.update_forces()`` to remove the check of force change.
* Update the ``Model.connect()`` to actively clear the error if any when the connection is constructed.
* Update the ``UtilityMonitor.update_position()`` to publish the position by IMS.
* Add the ``TabRigidBodyPos._create_group_ims_position()`` to show the position by IMS.
* Change the digit in detailed force widget.
* Update the condition to trigger the ``Model.fault()``.
* Update the ``Model._process_telemetry()`` to deal with the condition that the hardpoint correction of tangent link might be empty.