### PR TITLE
Tickets/dm 39571

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,20 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-0.6.1:
+
+-------------
+0.6.1
+-------------
+
+* Handle the error in ``Model.enter_enable()`` when failed to enable all the ILCs.
+* Allow to bypass the state check of ``Model.command_script()``.
+* Turn on the communication power at ``Model.enter_enable()`` instead of ``Model.enter_diagnostic()``.
+* Finetune the behavior and timeout for functions relate to the state transition.
+* Fix the typo in **TabDiagnostics** and **UtilityMonitor** classes.
+* User can set the retry times and timeout of the ILC state transition.
+* Filter the outlier of raw inclinometer value.
+
 .. _lsst.ts.m2gui-0.6.0:
 
 -------------

--- a/python/lsst/ts/m2gui/controltab/tab_diagnostics.py
+++ b/python/lsst/ts/m2gui/controltab/tab_diagnostics.py
@@ -255,7 +255,7 @@ class TabDiagnostics(TabDefault):
             "J3-W14-2 Communication Power Breaker OK",
             "Spare Input 29",
             "Spare Input 30",
-            "Interlock Power Replay On",
+            "Interlock Power Relay On",
         ]
 
     def _get_list_digital_status_output(self) -> list:

--- a/python/lsst/ts/m2gui/layout/layout_control_mode.py
+++ b/python/lsst/ts/m2gui/layout/layout_control_mode.py
@@ -109,4 +109,11 @@ class LayoutControlMode(LayoutDefault):
             True if turn on the force balance system, which means the system is
             going to do the closed-loop control. Otherwise, False.
         """
-        await run_command(self.model.controller.switch_force_balance_system, status)
+
+        self._prohibit_control_mode()
+        is_successful = await run_command(
+            self.model.controller.switch_force_balance_system, status
+        )
+
+        if not is_successful:
+            self._update_buttons()

--- a/python/lsst/ts/m2gui/utility_monitor.py
+++ b/python/lsst/ts/m2gui/utility_monitor.py
@@ -734,7 +734,7 @@ class UtilityMonitor(object):
 
         value_update = value
         for item in DigitalInput:
-            if ("PowerBreaker" in item.name) or ("PowerReplay" in item.name):
+            if ("PowerBreaker" in item.name) or ("PowerRelay" in item.name):
                 value_update = value_update ^ item.value
 
         return value_update

--- a/tests/controltab/test_tab_settings.py
+++ b/tests/controltab/test_tab_settings.py
@@ -51,6 +51,9 @@ def test_init(widget: TabSettings) -> None:
     assert widget._settings["enable_angle_comparison"].isChecked() is False
     assert widget._settings["max_angle_difference"].value() == 2.0
 
+    assert widget._settings["ilc_retry_times"].value() == widget.model.ilc_retry_times
+    assert widget._settings["ilc_timeout"].value() == widget.model.ilc_timeout
+
     assert widget._settings["log_level"].value() == widget.model.log.level
     assert widget._settings["refresh_frequency"].value() == int(
         1000 / widget.model.duration_refresh
@@ -122,6 +125,20 @@ async def test_callback_apply_host(qtbot: QtBot, widget: TabSettings) -> None:
     assert controller.port_command == 1
     assert controller.port_telemetry == 2
     assert controller.timeout_connection == 3
+
+
+@pytest.mark.asyncio
+async def test_callback_apply_ilc(qtbot: QtBot, widget: TabSettings) -> None:
+    widget._settings["ilc_retry_times"].setValue(10)
+    widget._settings["ilc_timeout"].setValue(30.15)
+
+    qtbot.mouseClick(widget._button_apply_ilc, Qt.LeftButton)
+
+    # Sleep so the event loop can access CPU to handle the signal
+    await asyncio.sleep(1)
+
+    assert widget.model.ilc_retry_times == 10
+    assert widget.model.ilc_timeout == 30.15
 
 
 @pytest.mark.asyncio

--- a/tests/controltab/test_tab_utility_view.py
+++ b/tests/controltab/test_tab_utility_view.py
@@ -68,8 +68,9 @@ def test_init(widget: TabUtilityView) -> None:
 
 @pytest.mark.asyncio
 async def test_callback_reset_breakers(widget_async: TabUtilityView) -> None:
-    # Transition to Diagnostic state to turn on the communication power
+    # Transition to Enabled state to turn on the communication power
     await widget_async.model.enter_diagnostic()
+    await widget_async.model.enter_enable()
 
     name = "J3-W14-2"
     widget_async.model.utility_monitor.update_breaker(name, True)

--- a/tests/layout/test_layout_local_mode.py
+++ b/tests/layout/test_layout_local_mode.py
@@ -137,7 +137,7 @@ async def test_set_local_mode(qtbot: QtBot, widget_async: MockWidget) -> None:
     )
 
     # Sleep so the event loop can access CPU to handle the signal
-    await asyncio.sleep(15)
+    await asyncio.sleep(20)
 
     assert widget_async.model.local_mode == LocalMode.Enable
 

--- a/tests/test_utility_monitor.py
+++ b/tests/test_utility_monitor.py
@@ -314,13 +314,13 @@ def test_update_digital_status_input(
 def test_process_digital_status_input(utility_monitor: UtilityMonitor) -> None:
     value = (
         DigitalInput.J1_W9_1_MotorPowerBreaker.value
-        + DigitalInput.InterlockPowerReplay.value
+        + DigitalInput.InterlockPowerRelay.value
     )
 
     value_update = utility_monitor._process_digital_status_input(value)
 
     assert value_update & DigitalInput.J1_W9_1_MotorPowerBreaker.value == 0
-    assert value_update & DigitalInput.InterlockPowerReplay.value == 0
+    assert value_update & DigitalInput.InterlockPowerRelay.value == 0
 
     assert (
         value_update & DigitalInput.J2_W10_3_MotorPowerBreaker.value


### PR DESCRIPTION
* Handle the error in ``Model.enter_enable()`` when failed to enable all the ILCs.
* Allow to bypass the state check of ``Model.command_script()``.
* Turn on the communication power at ``Model.enter_enable()`` instead of ``Model.enter_diagnostic()``.
* Finetune the behavior and timeout for functions relate to the state transition.
* Fix the typo in **TabDiagnostics** and **UtilityMonitor** classes.
* User can set the retry times and timeout of the ILC state transition.
* Filter the outlier of raw inclinometer value.