### PR TITLE
Bypass the actions if CSC is on.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,16 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-0.7.8:
+
+-------------
+0.7.8
+-------------
+
+* Bypass the actions if the CSC is connecting to the controller.
+* Update the ``LayoutControlMode._callback_signal_control()`` to show the open/closed loop control mode in the **Standby** state as well.
+This is to consider the case that the CSC might be using the M2 system at the same time.
+
 .. _lsst.ts.m2gui-0.7.7:
 
 -------------

--- a/python/lsst/ts/m2gui/layout/layout_control_mode.py
+++ b/python/lsst/ts/m2gui/layout/layout_control_mode.py
@@ -65,7 +65,7 @@ class LayoutControlMode(LayoutDefault):
 
     @asyncSlot()
     async def _callback_signal_control(self, is_control_updated: bool) -> None:
-        if self.model.local_mode == LocalMode.Enable:
+        if self.model.local_mode in (LocalMode.Standby, LocalMode.Enable):
             self._update_buttons()
         else:
             self._prohibit_control_mode()

--- a/tests/layout/test_layout_control_mode.py
+++ b/tests/layout/test_layout_control_mode.py
@@ -74,7 +74,7 @@ async def test_callback_signal_control_normal(qtbot: QtBot, widget: MockWidget) 
     await asyncio.sleep(1)
 
     assert widget.layout_control_mode._button_open_loop.isEnabled() is False
-    assert widget.layout_control_mode._button_closed_loop.isEnabled() is False
+    assert widget.layout_control_mode._button_closed_loop.isEnabled() is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Bypass the actions if the CSC is connecting to the controller.
* Update the ``LayoutControlMode._callback_signal_control()`` to show the open/closed loop control mode in the **Standby** state as well.
This is to consider the case that the CSC might be using the M2 system at the same time.