### PR TITLE
Run the internal job of fault as a task.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-1.1.6:
+
+-------------
+1.1.6
+-------------
+
+* Run the ``Model._basic_cleanup_and_power_off_motor()`` in ``Model.fault()`` as an asynchronous task to avoid the break of logic to turn off the motor power when there is the fault found in ``Model._process_event()``, which is a callback function.
+
 .. _lsst.ts.m2gui-1.1.5:
 
 -------------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -744,8 +744,14 @@ async def test_fault(model_async: Model) -> None:
     await model_async.enter_diagnostic()
     await model_async.enter_enable()
 
+    assert model_async.controller.power_system_status["motor_power_is_on"]
+
     await model_async.fault()
     assert model_async.local_mode == LocalMode.Diagnostic
+
+    await model_async._task_fault
+
+    assert not model_async.controller.power_system_status["motor_power_is_on"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Run the ``Model._basic_cleanup_and_power_off_motor()`` in ``Model.fault()`` as an asynchronous task to avoid the break of logic to turn off the motor power when there is the fault found in ``Model._process_event()``, which is a callback function.