### PR TITLE
Fix the unit of displacement sensor and support to fault the controller.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,16 @@
 Version History
 ##################
 
+.. _lsst.ts.m2gui-1.1.12:
+
+-------------
+1.1.12
+-------------
+
+- Fix the ``TabUtilityView._callback_displacements()`` to use the unit of um for displacement sensors.
+- Remove the ``Model.reboot_controller()`` and add the ``Model.fault_controller()``.
+- Remove the ``TabDiagnostics._callback_reboot_controller()`` and add the ``TabDiagnostics._callback_fault_controller()``.
+
 .. _lsst.ts.m2gui-1.1.11:
 
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,6 @@ license = { text = "GPL" }
 classifiers = [ "Programming Language :: Python :: 3" ]
 urls = {documentation = "https://ts-m2gui.lsst.io", repository = "https://github.com/lsst-ts/ts_m2gui" }
 dynamic = [ "version" ]
-dependencies = [
-    "pyside6",
-    "pyyaml",
-    "qasync",
-    "ts_m2com",
-    "ts_xml",
-    "ts_tcpip",
-    "ts_guitool",
-]
 
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }

--- a/python/lsst/ts/m2gui/controltab/tab_diagnostics.py
+++ b/python/lsst/ts/m2gui/controltab/tab_diagnostics.py
@@ -98,7 +98,7 @@ class TabDiagnostics(TabDefault):
             "tangent_sum": create_label(tool_tip=f"Threshold is {TANGENT_LINK_THETA_Z_MOMENT} N"),
         }
 
-        self._button_reboot = set_button("Reboot Controller", self._callback_reboot_controller)
+        self._button_fault = set_button("Fault Controller", self._callback_fault_controller)
 
         self._button_update_control_mode = set_button(
             "Update Control Mode",
@@ -141,14 +141,14 @@ class TabDiagnostics(TabDefault):
         }
 
     @asyncSlot()
-    async def _callback_reboot_controller(self) -> None:
-        """Callback of the reboot-cell-controller button. This will ask the
+    async def _callback_fault_controller(self) -> None:
+        """Callback of the fault-cell-controller button. This will ask the
         user to confirm this command again."""
 
         dialog = QMessageBoxAsync()
 
-        dialog.setText("This will reboot the cell controller.")
-        dialog.setInformativeText("Are you sure to reboot the controller?")
+        dialog.setText("This will fault the cell controller.")
+        dialog.setInformativeText("Are you sure to fault the controller?")
 
         dialog.setStandardButtons(QMessageBoxAsync.Ok | QMessageBoxAsync.Cancel)
         dialog.setDefaultButton(QMessageBoxAsync.Cancel)
@@ -158,7 +158,7 @@ class TabDiagnostics(TabDefault):
 
         decision = await dialog.show()
         if decision == QMessageBoxAsync.Ok:
-            await run_command(self.model.reboot_controller)
+            await run_command(self.model.fault_controller)
 
     @asyncSlot()
     async def _callback_update_control_mode(self) -> None:
@@ -404,7 +404,7 @@ class TabDiagnostics(TabDefault):
         layout_power_force_error.addWidget(self._create_group_force_error_non_load())
         layout_power_force_error.addWidget(self._create_group_force_error_total())
 
-        layout_power_force_error.addWidget(self._button_reboot)
+        layout_power_force_error.addWidget(self._button_fault)
 
         layout.addLayout(layout_power_force_error)
 

--- a/python/lsst/ts/m2gui/controltab/tab_utility_view.py
+++ b/python/lsst/ts/m2gui/controltab/tab_utility_view.py
@@ -540,7 +540,7 @@ class TabUtilityView(TabDefault):
             Displacements: (sensor_direction, [displacement_1, displacement_2,
             ...]). The data type of "sensor_direction" is the enum:
             `DisplacementSensorDirection`. The data type of displacement in
-            "[displacement_1, displacement_2, ...]" is float. The unit is mm.
+            "[displacement_1, displacement_2, ...]" is float. The unit is um.
             This list should have all the displacements in the direction.
         """
 
@@ -549,4 +549,4 @@ class TabUtilityView(TabDefault):
 
         sensors = self.model.utility_monitor.get_displacement_sensors(sensor_direction)
         for sensor, value in zip(sensors, values):
-            self._displacements[sensor].setText(f"{value} mm")
+            self._displacements[sensor].setText(f"{value} um")

--- a/python/lsst/ts/m2gui/model.py
+++ b/python/lsst/ts/m2gui/model.py
@@ -429,8 +429,8 @@ class Model(object):
         """
         return self.local_mode == LocalMode.Enable and self.is_closed_loop
 
-    async def reboot_controller(self) -> None:
-        """Reboot the cell controller.
+    async def fault_controller(self) -> None:
+        """Fault the cell controller.
 
         Raises
         ------
@@ -438,10 +438,10 @@ class Model(object):
             Not in the standby state with local control.
         """
 
-        if self.local_mode == LocalMode.Standby and not self.is_csc_commander:
-            await self.controller.reboot_controller()
+        if not self.is_csc_commander:
+            await self.controller.fault_controller()
         else:
-            raise RuntimeError("Controller can only be rebooted at the standby state with local control.")
+            raise RuntimeError("Controller can only be faulted with local control.")
 
     async def command_script(
         self,

--- a/tests/controltab/test_tab_utility_view.py
+++ b/tests/controltab/test_tab_utility_view.py
@@ -169,4 +169,4 @@ async def test_callback_displacements(qtbot: QtBot, widget: TabUtilityView) -> N
 
     sensors = utility_monitor.get_displacement_sensors(direction)
     for sensor, displacement in zip(sensors, displacements):
-        assert widget._displacements[sensor].text() == f"{displacement} mm"
+        assert widget._displacements[sensor].text() == f"{displacement} um"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -196,14 +196,10 @@ async def test_go_to_position_exception(model: Model) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reboot_controller_exception(model: Model) -> None:
-    with pytest.raises(RuntimeError):
-        model.local_mode = LocalMode.Diagnostic
-        await model.reboot_controller()
-
+async def test_fault_controller_exception(model: Model) -> None:
     with pytest.raises(RuntimeError):
         model.is_csc_commander = True
-        await model.reboot_controller()
+        await model.fault_controller()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Fix the ``TabUtilityView._callback_displacements()`` to use the unit of um for displacement sensors.
- Remove the ``Model.reboot_controller()`` and add the ``Model.fault_controller()``.
- Remove the ``TabDiagnostics._callback_reboot_controller()`` and add the ``TabDiagnostics._callback_fault_controller()``.